### PR TITLE
Fixing namespace issue with local dev

### DIFF
--- a/kubernetes/app.yaml
+++ b/kubernetes/app.yaml
@@ -1,8 +1,15 @@
 ---
 apiVersion: v1
+kind: Namespace
+metadata:
+  name: push-deploy
+
+---
+apiVersion: v1
 kind: ConfigMap
 metadata:
   name: push-deploy-config
+  namespace: push-deploy
 data:
   FLASK_ENV: development
   PD_REGISTRY: docker.io/
@@ -17,6 +24,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: push-deploy-secrets
+  namespace: push-deploy
 type: Opaque
 data:
   PD_SECRET_KEY: dXNDdUtuclFiU0ZjbkE1eEJjalBKZHFTRGFTQmlrVkFwUmJFT2xtZlhzbDRPQXdSVXZhalVqc2NXNEVjdzZ2Yw==


### PR DESCRIPTION
Changes:
- Fixes issue where it is assumed the a namespace `push-deploy` exists.
- Fixes issue where configMaps are created in the default namespace and are not found by the pods.

Signed-off-by: mdgreenwald <mdgreenwald@gmail.com>